### PR TITLE
Fix contrast for yellow chat

### DIFF
--- a/style.css
+++ b/style.css
@@ -218,3 +218,6 @@ input:placeholder-shown {
 ._nd_ ._52mr ._4br2 {
 	display: none !important;
 }
+._nd_ ._hh7[style*="background-color: rgb(255, 195, 0);"] {
+	color: black;
+}

--- a/style.css
+++ b/style.css
@@ -221,3 +221,6 @@ input:placeholder-shown {
 ._nd_ ._hh7[style*="background-color: rgb(255, 195, 0);"] {
 	color: black;
 }
+._nd_ ._hh7[style="background-color: rgb(255, 195, 0);"] a {
+	color: darkblue;
+}


### PR DESCRIPTION
The default white text on yellow speech bubble is unreadable; now black for contrast